### PR TITLE
Prevent API request for views data for deleted documents

### DIFF
--- a/app/components/Collaborators.js
+++ b/app/components/Collaborators.js
@@ -20,7 +20,9 @@ type Props = {
 @observer
 class Collaborators extends React.Component<Props> {
   componentDidMount() {
-    this.props.views.fetchPage({ documentId: this.props.document.id });
+    if (!this.props.document.deletedAt) {
+      this.props.views.fetchPage({ documentId: this.props.document.id });
+    }
   }
 
   render() {


### PR DESCRIPTION
Added a conditional statement to check if the `document.deletedAt` is falsy before making a request to` views.list`.